### PR TITLE
make mapToDTOList method to be a default interface method

### DIFF
--- a/src/main/java/academy/softserve/movieuniverse/service/mapper/CommentMapper.java
+++ b/src/main/java/academy/softserve/movieuniverse/service/mapper/CommentMapper.java
@@ -8,9 +8,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 @Component
@@ -33,10 +30,4 @@ public class CommentMapper implements DTOMapper<CommentDTO, CommentRequest, Comm
         commentDTO.add(linkTo(CommentController.class).slash(commentDTO.getCommentId()).withSelfRel());
         return commentDTO;
     }
-
-    @Override
-    public List<CommentDTO> mapToDTOList(List<Comment> entities) {
-        return  entities.stream().map(this::mapToDTO).collect(Collectors.toList());
-    }
-
 }

--- a/src/main/java/academy/softserve/movieuniverse/service/mapper/DTOMapper.java
+++ b/src/main/java/academy/softserve/movieuniverse/service/mapper/DTOMapper.java
@@ -8,7 +8,9 @@ public interface DTOMapper<D, I, E> {
 
     D mapToDTO(E entity);
 
-    List<D> mapToDTOList(List<E> entities);
+    default List<D> mapToDTOList(List<E> entities) {
+        return entities.stream().map(this::mapToDTO).collect(Collectors.toList());
+    }
 
     default List<E> mapToEntityList(List<I> dtos) {
         return dtos.stream().map(this::mapToEntity).collect(Collectors.toList());

--- a/src/main/java/academy/softserve/movieuniverse/service/mapper/GenreMapper.java
+++ b/src/main/java/academy/softserve/movieuniverse/service/mapper/GenreMapper.java
@@ -9,9 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 @Component
@@ -34,10 +31,5 @@ public class GenreMapper implements DTOMapper<GenreDTO, GenreRequest,  Genre> {
     @Override
     public Genre mapToEntity(GenreRequest dto) {
         return modelMapper.map(dto, Genre.class);
-    }
-
-    @Override
-    public List<GenreDTO> mapToDTOList(List<Genre> genres) {
-        return genres.stream().map(this::mapToDTO).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
There is no need to implement mapToDTOList method in every mapper as it does the same basic entity list mapping operation